### PR TITLE
ci(workflows): Update environment in npm-publish

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -17,7 +17,6 @@ on:
         type: string
 
 jobs:
-  environment: 'production'
   # Only run if the release workflow was successful
   check-release-success:
     if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
@@ -50,7 +49,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' && needs.check-release-success.outputs.should-run == 'true')
     needs: [check-release-success]
-    environment: npm-publishing  # This links to your GitHub environment
+    environment: production
     strategy:
       matrix:
         platform:
@@ -147,7 +146,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' && needs.check-release-success.outputs.should-run == 'true')
     needs: [check-release-success, publish-platform-packages]
-    environment: npm-publishing  # This links to your GitHub environment
+    environment: production
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Replaced 'npm-publishing' environment with 'production' in multiple job configurations within the npm-publish GitHub Actions workflow. This ensures consistency and aligns with the intended deployment environment.