### PR TITLE
Add OpenAPI x-nullable extension support for io-ts generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cross-platform NPM package support with proper binary installation
 - Support for `npx dtoforge` usage without installation
 - Better error handling and cross-platform compatibility in NPM package
+- **OpenAPI Extensions Support**: Added support for `x-nullable` extension to explicitly mark fields as nullable
+  - Currently available for io-ts generator (Zod support coming soon)
+  - Configurable via `extensions.x-nullable.enabled` setting
+  - Allows precise control over nullable fields, even for required properties
 
 ### Changed
 - **BREAKING:** Removed "Codec" suffix from generated TypeScript types (`User` instead of `UserCodec`)
@@ -28,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - NPM global installation now works correctly on all platforms
+- Property names with invalid JavaScript identifiers (e.g., `@method`) are now properly quoted in generated TypeScript
+- Single-file generation mode now correctly orders type definitions to avoid "used before declaration" errors
+- Fixed TypeScript compilation errors when generating code from large OpenAPI specifications (1500+ schemas)
 - Binary execution permissions on Unix-like systems
 - Cross-platform path handling in NPM package
 - Package.json binary path consistency

--- a/README.md
+++ b/README.md
@@ -218,9 +218,67 @@ generation:
   generateSchemaRegistry: false  # Generate schema registry object (default: false)
   generateSchemaNames: false  # Generate schema names array (default: false)
   useInterfaces: true  # Use interfaces instead of type aliases (default: true)
+
+# OpenAPI extensions support
+extensions:
+  x-nullable:
+    enabled: true  # Enable x-nullable extension support (default: true)
 ```
 
 ## 🔧 Advanced Features
+
+### OpenAPI Extensions Support (x-nullable)
+
+DtoForge supports the `x-nullable` OpenAPI extension to explicitly mark fields as nullable, providing more precise type generation than the standard `nullable` property.
+
+**Note:** Currently supported for io-ts generator only. Zod support coming soon.
+
+#### Usage in OpenAPI Schema:
+```yaml
+components:
+  schemas:
+    User:
+      type: object
+      required: [id, email]
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+          x-nullable: true  # Email is required but can be null
+        phone:
+          type: string
+          x-nullable: false  # Explicitly not nullable (optional)
+        address:
+          type: string  # Regular optional field
+```
+
+#### Generated TypeScript (io-ts):
+```typescript
+export const User = t.intersection([
+  t.type({
+    id: t.string,
+    email: t.union([t.string, t.null]), // Required but nullable
+  }),
+  t.partial({
+    phone: t.string,  // Optional, not nullable
+    address: t.string, // Optional, not nullable
+  })
+])
+```
+
+#### Key Differences:
+- **Standard `nullable`**: Makes a field accept null values
+- **`x-nullable: true`**: Explicitly makes the field nullable, even if required
+- **`x-nullable: false`**: Explicitly prevents null, useful for documentation
+
+#### Configuration:
+You can disable x-nullable processing if needed:
+```yaml
+extensions:
+  x-nullable:
+    enabled: false  # Disable x-nullable extension support
+```
 
 ### Custom Branded Types
 ```typescript

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -17,13 +17,14 @@ type DTO struct {
 
 // Property represents a field within a DTO.
 type Property struct {
-	Name          string            `json:"name"`
-	Type          IRType            `json:"type"`
-	Description   string            `json:"description"`
-	Nullable      bool              `json:"nullable"`
-	Required      bool              `json:"required"`
-	CustomBranded string            `json:"customBranded,omitempty"`
-	Metadata      map[string]string `json:"metadata,omitempty"`
+	Name          string                 `json:"name"`
+	Type          IRType                 `json:"type"`
+	Description   string                 `json:"description"`
+	Nullable      bool                   `json:"nullable"`
+	Required      bool                   `json:"required"`
+	CustomBranded string                 `json:"customBranded,omitempty"`
+	Metadata      map[string]string      `json:"metadata,omitempty"`
+	Extensions    map[string]interface{} `json:"extensions,omitempty"` // OpenAPI extensions (x-*)
 }
 
 // IRType is an interface for our type representations.

--- a/internal/typescript/common.go
+++ b/internal/typescript/common.go
@@ -211,6 +211,31 @@ func hasDescription(desc string) bool {
 	return strings.TrimSpace(desc) != ""
 }
 
+// hasXNullable checks if a property has x-nullable: true extension
+func hasXNullable(prop generator.Property, customTypes *CustomTypeRegistry) bool {
+	// Check if x-nullable handling is enabled
+	if !customTypes.IsXNullableEnabled() {
+		return false
+	}
+
+	if prop.Extensions == nil {
+		return false
+	}
+	if xNullable, ok := prop.Extensions["x-nullable"]; ok {
+		if boolVal, ok := xNullable.(bool); ok {
+			return boolVal
+		}
+	}
+	return false
+}
+
+// propertyToIoTsType converts a property to io-ts type considering x-nullable
+func propertyToIoTsType(prop generator.Property, customTypes *CustomTypeRegistry) string {
+	// Check if property should be nullable due to x-nullable extension
+	nullable := prop.Nullable || hasXNullable(prop, customTypes)
+	return toIoTsType(prop.Type, nullable, customTypes)
+}
+
 // quote wraps a string in single quotes
 func quote(s string) string {
 	return fmt.Sprintf("'%s'", s)

--- a/internal/typescript/custom_types.go
+++ b/internal/typescript/custom_types.go
@@ -32,11 +32,19 @@ type CustomTypeMapping struct {
 	ImportStatement string `yaml:"import"`
 }
 
+// ExtensionConfig represents configuration for OpenAPI extensions
+type ExtensionConfig struct {
+	XNullable struct {
+		Enabled bool `yaml:"enabled"`
+	} `yaml:"x-nullable"`
+}
+
 // EnhancedCustomTypeConfig represents the complete YAML configuration structure
 type EnhancedCustomTypeConfig struct {
 	Output      OutputConfig                 `yaml:"output"`
 	CustomTypes map[string]CustomTypeMapping `yaml:"customTypes"`
 	Generation  GenerationConfig             `yaml:"generation"`
+	Extensions  ExtensionConfig              `yaml:"extensions"`
 }
 
 // CustomTypeRegistry holds all custom type mappings and config
@@ -44,6 +52,7 @@ type CustomTypeRegistry struct {
 	mappings   map[string]CustomTypeMapping
 	output     OutputConfig
 	generation GenerationConfig
+	extensions ExtensionConfig
 }
 
 // NewCustomTypeRegistry creates a new registry with default mappings and config
@@ -63,7 +72,11 @@ func NewCustomTypeRegistry() *CustomTypeRegistry {
 			GenerateSchemaNames:    false,
 			UseInterfaces:          true,
 		},
+		extensions: ExtensionConfig{},
 	}
+
+	// Enable x-nullable by default
+	registry.extensions.XNullable.Enabled = true
 
 	registry.addDefaultMappings()
 	return registry
@@ -77,6 +90,11 @@ func (r *CustomTypeRegistry) GetOutputConfig() OutputConfig {
 // GetGenerationConfig returns the generation configuration
 func (r *CustomTypeRegistry) GetGenerationConfig() GenerationConfig {
 	return r.generation
+}
+
+// IsXNullableEnabled returns true if x-nullable extension handling is enabled
+func (r *CustomTypeRegistry) IsXNullableEnabled() bool {
+	return r.extensions.XNullable.Enabled
 }
 
 // IsSingleFileMode returns true if single file output is configured
@@ -201,6 +219,9 @@ func (r *CustomTypeRegistry) LoadFromConfig(configPath string) error {
 	r.generation.GenerateSchemaRegistry = config.Generation.GenerateSchemaRegistry
 	r.generation.GenerateSchemaNames = config.Generation.GenerateSchemaNames
 	r.generation.UseInterfaces = config.Generation.UseInterfaces
+
+	// Load extensions config
+	r.extensions = config.Extensions
 
 	// Register all custom types from config
 	for format, mapping := range config.CustomTypes {

--- a/internal/typescript/extensions_test.go
+++ b/internal/typescript/extensions_test.go
@@ -1,0 +1,286 @@
+package typescript
+
+import (
+	"dtoForge/internal/generator"
+	"dtoForge/internal/testutils"
+	"path/filepath"
+	"testing"
+)
+
+func TestTypeScriptGenerator_XNullableExtension(t *testing.T) {
+	gen := NewTypeScriptGenerator()
+	tempDir := testutils.TempDir(t)
+
+	// Create a DTO with x-nullable extension
+	dto := generator.DTO{
+		Name:        "User",
+		Type:        "object",
+		Description: "User with nullable fields",
+		Required:    []string{"id"},
+		Properties: []generator.Property{
+			{
+				Name:        "id",
+				Type:        generator.PrimitiveType{Name: "string"},
+				Description: "User ID",
+				Required:    true,
+			},
+			{
+				Name:        "email",
+				Type:        generator.PrimitiveType{Name: "string", Format: "email"},
+				Description: "User email (nullable via x-nullable)",
+				Required:    false,
+				Extensions: map[string]interface{}{
+					"x-nullable": true,
+				},
+			},
+			{
+				Name:        "phone",
+				Type:        generator.PrimitiveType{Name: "string"},
+				Description: "Phone number (not nullable)",
+				Required:    false,
+				Extensions: map[string]interface{}{
+					"x-nullable": false,
+				},
+			},
+			{
+				Name:        "address",
+				Type:        generator.PrimitiveType{Name: "string"},
+				Description: "Address (no x-nullable)",
+				Required:    false,
+			},
+		},
+	}
+
+	config := generator.Config{
+		OutputFolder:   tempDir,
+		PackageName:    "test-extensions",
+		TargetLanguage: "typescript",
+	}
+
+	err := gen.Generate([]generator.DTO{dto}, config)
+	if err != nil {
+		t.Fatalf("Generate() failed: %v", err)
+	}
+
+	// Check generated file
+	userFile := filepath.Join(tempDir, "user.ts")
+	testutils.AssertFileExists(t, userFile)
+
+	// Check that email is nullable (x-nullable: true)
+	testutils.AssertFileContains(t, userFile, "email: t.union([t.string, t.null])")
+
+	// Check that phone is not nullable (x-nullable: false)
+	testutils.AssertFileContains(t, userFile, "phone: t.string")
+
+	// Check that address is not nullable (no x-nullable)
+	testutils.AssertFileContains(t, userFile, "address: t.string")
+}
+
+func TestTypeScriptGenerator_XNullableWithRequired(t *testing.T) {
+	gen := NewTypeScriptGenerator()
+	tempDir := testutils.TempDir(t)
+
+	// Test x-nullable on required fields
+	dto := generator.DTO{
+		Name:        "Product",
+		Type:        "object",
+		Description: "Product with nullable required field",
+		Required:    []string{"name", "description"},
+		Properties: []generator.Property{
+			{
+				Name:        "name",
+				Type:        generator.PrimitiveType{Name: "string"},
+				Description: "Product name (required but nullable)",
+				Required:    true,
+				Extensions: map[string]interface{}{
+					"x-nullable": true,
+				},
+			},
+			{
+				Name:        "description",
+				Type:        generator.PrimitiveType{Name: "string"},
+				Description: "Product description (required, not nullable)",
+				Required:    true,
+			},
+		},
+	}
+
+	config := generator.Config{
+		OutputFolder:   tempDir,
+		PackageName:    "test-nullable-required",
+		TargetLanguage: "typescript",
+	}
+
+	err := gen.Generate([]generator.DTO{dto}, config)
+	if err != nil {
+		t.Fatalf("Generate() failed: %v", err)
+	}
+
+	productFile := filepath.Join(tempDir, "product.ts")
+
+	// Required + x-nullable should be: field: t.union([t.string, t.null])
+	testutils.AssertFileContains(t, productFile, "name: t.union([t.string, t.null])")
+
+	// Required without x-nullable should be: field: t.string
+	testutils.AssertFileContains(t, productFile, "description: t.string")
+}
+
+func TestTypeScriptGenerator_XNullableConfig(t *testing.T) {
+	gen := NewTypeScriptGenerator()
+	tempDir := testutils.TempDir(t)
+
+	// Create config that disables x-nullable handling
+	configContent := `extensions:
+  x-nullable:
+    enabled: false`
+
+	configPath := testutils.WriteFile(t, tempDir, "config.yaml", configContent)
+
+	dto := generator.DTO{
+		Name:     "Settings",
+		Type:     "object",
+		Required: []string{},
+		Properties: []generator.Property{
+			{
+				Name:     "theme",
+				Type:     generator.PrimitiveType{Name: "string"},
+				Required: false,
+				Extensions: map[string]interface{}{
+					"x-nullable": true, // Should be ignored when disabled
+				},
+			},
+		},
+	}
+
+	config := generator.Config{
+		OutputFolder:   tempDir,
+		PackageName:    "test-disabled-nullable",
+		TargetLanguage: "typescript",
+		ConfigFile:     configPath,
+	}
+
+	err := gen.Generate([]generator.DTO{dto}, config)
+	if err != nil {
+		t.Fatalf("Generate() failed: %v", err)
+	}
+
+	settingsFile := filepath.Join(tempDir, "settings.ts")
+
+	// With x-nullable disabled, should generate normal optional
+	testutils.AssertFileContains(t, settingsFile, "theme: t.string")
+	testutils.AssertFileNotContains(t, settingsFile, "t.union([t.string, t.null])")
+}
+
+func TestTypeScriptGenerator_XNullableWithArrays(t *testing.T) {
+	gen := NewTypeScriptGenerator()
+	tempDir := testutils.TempDir(t)
+
+	dto := generator.DTO{
+		Name:     "Collection",
+		Type:     "object",
+		Required: []string{},
+		Properties: []generator.Property{
+			{
+				Name: "items",
+				Type: generator.ArrayType{
+					ElementType: generator.PrimitiveType{Name: "string"},
+				},
+				Required: false,
+				Extensions: map[string]interface{}{
+					"x-nullable": true,
+				},
+			},
+			{
+				Name: "tags",
+				Type: generator.ArrayType{
+					ElementType: generator.PrimitiveType{Name: "string"},
+				},
+				Required: true,
+				Extensions: map[string]interface{}{
+					"x-nullable": true,
+				},
+			},
+		},
+	}
+
+	config := generator.Config{
+		OutputFolder:   tempDir,
+		PackageName:    "test-nullable-arrays",
+		TargetLanguage: "typescript",
+	}
+
+	err := gen.Generate([]generator.DTO{dto}, config)
+	if err != nil {
+		t.Fatalf("Generate() failed: %v", err)
+	}
+
+	collectionFile := filepath.Join(tempDir, "collection.ts")
+
+	// Optional array with x-nullable
+	testutils.AssertFileContains(t, collectionFile, "items: t.union([t.array(t.string), t.null])")
+
+	// Required array with x-nullable
+	testutils.AssertFileContains(t, collectionFile, "tags: t.union([t.array(t.string), t.null])")
+}
+
+func TestTypeScriptGenerator_XNullableWithReferences(t *testing.T) {
+	gen := NewTypeScriptGenerator()
+	tempDir := testutils.TempDir(t)
+
+	dtos := []generator.DTO{
+		{
+			Name:     "Address",
+			Type:     "object",
+			Required: []string{"street"},
+			Properties: []generator.Property{
+				{
+					Name:     "street",
+					Type:     generator.PrimitiveType{Name: "string"},
+					Required: true,
+				},
+			},
+		},
+		{
+			Name:     "Person",
+			Type:     "object",
+			Required: []string{},
+			Properties: []generator.Property{
+				{
+					Name:     "homeAddress",
+					Type:     generator.ReferenceType{RefName: "Address"},
+					Required: false,
+					Extensions: map[string]interface{}{
+						"x-nullable": true,
+					},
+				},
+				{
+					Name:     "workAddress",
+					Type:     generator.ReferenceType{RefName: "Address"},
+					Required: true,
+					Extensions: map[string]interface{}{
+						"x-nullable": true,
+					},
+				},
+			},
+		},
+	}
+
+	config := generator.Config{
+		OutputFolder:   tempDir,
+		PackageName:    "test-nullable-refs",
+		TargetLanguage: "typescript",
+	}
+
+	err := gen.Generate(dtos, config)
+	if err != nil {
+		t.Fatalf("Generate() failed: %v", err)
+	}
+
+	personFile := filepath.Join(tempDir, "person.ts")
+
+	// Optional reference with x-nullable
+	testutils.AssertFileContains(t, personFile, "homeAddress: t.union([Address, t.null])")
+
+	// Required reference with x-nullable
+	testutils.AssertFileContains(t, personFile, "workAddress: t.union([Address, t.null])")
+}

--- a/internal/typescript/multi_file.go
+++ b/internal/typescript/multi_file.go
@@ -184,6 +184,9 @@ func (g *MultiFileGenerator) templateFuncs() template.FuncMap {
 		"toTSType": func(irType generator.IRType, nullable bool) string {
 			return toTSType(irType, nullable, g.customTypes)
 		},
+		"propertyToIoTsType": func(prop generator.Property) string {
+			return propertyToIoTsType(prop, g.customTypes)
+		},
 		"toCamelCase":          toCamelCase,
 		"toPascalCase":         toPascalCase,
 		"toKebabCase":          toKebabCase,

--- a/internal/typescript/single_file.go
+++ b/internal/typescript/single_file.go
@@ -140,6 +140,9 @@ func (g *SingleFileGenerator) templateFuncs() template.FuncMap {
 		"toTSType": func(irType generator.IRType, nullable bool) string {
 			return toTSType(irType, nullable, g.customTypes)
 		},
+		"propertyToIoTsType": func(prop generator.Property) string {
+			return propertyToIoTsType(prop, g.customTypes)
+		},
 		"toCamelCase":          toCamelCase,
 		"toPascalCase":         toPascalCase,
 		"toKebabCase":          toKebabCase,

--- a/internal/typescript/templates.go
+++ b/internal/typescript/templates.go
@@ -26,15 +26,15 @@ export const decode{{.DTO.Name}} = (value: unknown) =>
 {{if .HasRequiredFields}}export const {{.DTO.Name}} = t.intersection([
   t.type({
 {{range .DTO.Properties}}{{if .Required}}{{if hasDescription .Description}}    // {{.Description}}
-{{end}}    {{safePropertyName .Name}}: {{toIoTsType .Type .Nullable}},
+{{end}}    {{safePropertyName .Name}}: {{propertyToIoTsType .}},
 {{end}}{{end}}  }),
   t.partial({
 {{range .DTO.Properties}}{{if not .Required}}{{if hasDescription .Description}}    // {{.Description}}
-{{end}}    {{safePropertyName .Name}}: {{toIoTsType .Type .Nullable}},
+{{end}}    {{safePropertyName .Name}}: {{propertyToIoTsType .}},
 {{end}}{{end}}  })
 ]){{else}}export const {{.DTO.Name}} = t.partial({
 {{range .DTO.Properties}}{{if hasDescription .Description}}  // {{.Description}}
-{{end}}  {{safePropertyName .Name}}: {{toIoTsType .Type .Nullable}},
+{{end}}  {{safePropertyName .Name}}: {{propertyToIoTsType .}},
 {{end}}}){{end}}
 
 {{if eq .DTO.Type "enum"}}export type {{.DTO.Name}} = t.TypeOf<typeof {{.DTO.Name}}>;{{/* Enums must always use type, not interface */}}{{else if .UseInterfaces}}export interface {{.DTO.Name}} extends t.TypeOf<typeof {{.DTO.Name}}> {}{{else}}export type {{.DTO.Name}} = t.TypeOf<typeof {{.DTO.Name}}>;{{end}}
@@ -49,7 +49,7 @@ export const decode{{.DTO.Name}} = (value: unknown) =>
 
 {{if .GeneratePartialCodecs}}// Partial codec for updates (all fields optional)
 export const {{.DTO.Name}}Partial = t.partial({
-{{range .DTO.Properties}}  {{safePropertyName .Name}}: {{toIoTsType .Type .Nullable}},
+{{range .DTO.Properties}}  {{safePropertyName .Name}}: {{propertyToIoTsType .}},
 {{end}}});
 
 {{if not $.UseInterfaces}}export type {{.DTO.Name}}Partial = t.TypeOf<typeof {{.DTO.Name}}Partial>;{{end}}{{end}}
@@ -182,22 +182,22 @@ export type {{.DTO.Name}} = t.TypeOf<typeof {{.DTO.Name}}>;{{/* Enums must alway
 {{if .HasRequiredFields}}export const {{.DTO.Name}} = t.intersection([
   t.type({
 {{range .DTO.Properties}}{{if .Required}}{{if hasDescription .Description}}    // {{.Description}}
-{{end}}    {{safePropertyName .Name}}: {{toIoTsType .Type .Nullable}},
+{{end}}    {{safePropertyName .Name}}: {{propertyToIoTsType .}},
 {{end}}{{end}}  }),
   t.partial({
 {{range .DTO.Properties}}{{if not .Required}}{{if hasDescription .Description}}    // {{.Description}}
-{{end}}    {{safePropertyName .Name}}: {{toIoTsType .Type .Nullable}},
+{{end}}    {{safePropertyName .Name}}: {{propertyToIoTsType .}},
 {{end}}{{end}}  })
 ]){{else}}export const {{.DTO.Name}} = t.partial({
 {{range .DTO.Properties}}{{if hasDescription .Description}}  // {{.Description}}
-{{end}}  {{safePropertyName .Name}}: {{toIoTsType .Type .Nullable}},
+{{end}}  {{safePropertyName .Name}}: {{propertyToIoTsType .}},
 {{end}}}){{end}}
 
 {{if eq .DTO.Type "enum"}}export type {{.DTO.Name}} = t.TypeOf<typeof {{.DTO.Name}}>;{{/* Enums must always use type, not interface */}}{{else if $.UseInterfaces}}export interface {{.DTO.Name}} extends t.TypeOf<typeof {{.DTO.Name}}> {}{{else}}export type {{.DTO.Name}} = t.TypeOf<typeof {{.DTO.Name}}>;{{end}}
 
 {{if $.GeneratePartialCodecs}}// Partial codec for updates (all fields optional)
 export const {{.DTO.Name}}Partial = t.partial({
-{{range .DTO.Properties}}  {{safePropertyName .Name}}: {{toIoTsType .Type .Nullable}},
+{{range .DTO.Properties}}  {{safePropertyName .Name}}: {{propertyToIoTsType .}},
 {{end}}});
 
 {{if not $.UseInterfaces}}export type {{.DTO.Name}}Partial = t.TypeOf<typeof {{.DTO.Name}}Partial>;{{end}}

--- a/main.go
+++ b/main.go
@@ -228,8 +228,9 @@ func convertSchemaToGeneratorDTO(name string, schema map[string]interface{}) (ge
 
 func convertSchemaToGeneratorProperty(name string, schema map[string]interface{}, required []string) (generator.Property, error) {
 	prop := generator.Property{
-		Name:     name,
-		Metadata: make(map[string]string),
+		Name:       name,
+		Metadata:   make(map[string]string),
+		Extensions: make(map[string]interface{}),
 	}
 
 	// Check if property is required
@@ -246,6 +247,13 @@ func convertSchemaToGeneratorProperty(name string, schema map[string]interface{}
 
 	if nullable, ok := schema["nullable"].(bool); ok {
 		prop.Nullable = nullable
+	}
+
+	// Parse OpenAPI extensions (x-* fields)
+	for key, value := range schema {
+		if strings.HasPrefix(key, "x-") {
+			prop.Extensions[key] = value
+		}
 	}
 
 	// Handle enum within property


### PR DESCRIPTION
- Add x-nullable extension parsing in schema conversion
- Support nullable required fields via x-nullable: true
- Add configuration option to enable/disable x-nullable handling
- Implement propertyToIoTsType function for extension-aware type generation
- Add comprehensive test coverage for x-nullable scenarios
- Update documentation with usage examples and configuration options