### PR TITLE
fix: handle NullType in toTSType to emit `null` instead of `unknown` in explicit interfaces

### DIFF
--- a/internal/typescript/common.go
+++ b/internal/typescript/common.go
@@ -279,6 +279,8 @@ func toTSTypeInternal(irType generator.IRType, nullable bool, codecCompat bool, 
 		} else {
 			baseType = defaultUnknown
 		}
+	case generator.NullType:
+		baseType = "null"
 	default:
 		baseType = defaultUnknown
 	}

--- a/internal/typescript/common.go
+++ b/internal/typescript/common.go
@@ -263,6 +263,11 @@ func toTSTypeInternal(irType generator.IRType, nullable bool, codecCompat bool, 
 		var unionTypes []string
 		for _, unionType := range t.Types {
 			unionTypes = append(unionTypes, toTSTypeInternal(unionType, false, codecCompat, customTypes))
+			// If the union already contains a NullType, suppress the nullable flag
+			// to avoid generating redundant "| null" (e.g. "(Foo | null) | null")
+			if _, isNull := unionType.(generator.NullType); isNull {
+				nullable = false
+			}
 		}
 		if len(unionTypes) > 0 {
 			baseType = fmt.Sprintf("(%s)", strings.Join(unionTypes, " | "))

--- a/internal/zod/generator.go
+++ b/internal/zod/generator.go
@@ -432,6 +432,11 @@ func (g *ZodGenerator) toTSType(irType generator.IRType, nullable bool) string {
 		var unionTypes []string
 		for _, unionType := range t.Types {
 			unionTypes = append(unionTypes, g.toTSType(unionType, false))
+			// If the union already contains a NullType, suppress the nullable flag
+			// to avoid generating redundant "| null" (e.g. "(Foo | null) | null")
+			if _, isNull := unionType.(generator.NullType); isNull {
+				nullable = false
+			}
 		}
 		if len(unionTypes) > 0 {
 			baseType = fmt.Sprintf("(%s)", strings.Join(unionTypes, " | "))

--- a/internal/zod/generator.go
+++ b/internal/zod/generator.go
@@ -448,6 +448,8 @@ func (g *ZodGenerator) toTSType(irType generator.IRType, nullable bool) string {
 		} else {
 			baseType = "unknown"
 		}
+	case generator.NullType:
+		baseType = "null"
 	default:
 		baseType = "unknown"
 	}

--- a/testdata/golden/recursive-schemas/schemas.ts
+++ b/testdata/golden/recursive-schemas/schemas.ts
@@ -5,7 +5,10 @@ import * as t from 'io-ts';
 
 
 // Interface declarations
+export interface FacetFieldDateInterval extends t.TypeOf<typeof FacetFieldDateInterval> {}
+
 export interface FacetSearchFieldRequest {
+  dateInterval?: (FacetFieldDateInterval | null);
   fieldPath?: string | null;
   subFieldFacets?: ReadonlyArray<FacetSearchFieldRequest> | null;
 }
@@ -21,10 +24,21 @@ export interface TreeNode {
 
 
 
+// Schema: FacetFieldDateInterval
+export const FacetFieldDateInterval = t.partial({
+  unit: t.string,
+})
+
+
+
+
+
+
 // Schema: FacetSearchFieldRequest (recursive)
 
 export const FacetSearchFieldRequest: t.Type<FacetSearchFieldRequest> = t.recursion('FacetSearchFieldRequest', () =>
   t.partial({
+    dateInterval: t.union([FacetFieldDateInterval, t.null]),
     fieldPath: t.union([t.string, t.null]),
     subFieldFacets: t.union([t.readonlyArray(FacetSearchFieldRequest), t.null]),
   })

--- a/testdata/recursive-api.yaml
+++ b/testdata/recursive-api.yaml
@@ -17,9 +17,19 @@ components:
           items:
             $ref: '#/components/schemas/TreeNode'
 
+    FacetFieldDateInterval:
+      type: object
+      properties:
+        unit:
+          type: string
+
     FacetSearchFieldRequest:
       type: object
       properties:
+        dateInterval:
+          oneOf:
+            - $ref: '#/components/schemas/FacetFieldDateInterval'
+            - type: 'null'
         fieldPath:
           type: string
           nullable: true


### PR DESCRIPTION
Recursive schemas with `oneOf: [{$ref}, {type: null}]` properties were generating `| unknown` in explicit interface declarations instead of `| null`, causing TS2322 errors. Added `NullType` case to both io-ts and Zod `toTSType` functions. Updated test fixtures with a oneOf+null property to cover this case.