### PR TITLE
ci: publish to npm via OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -16,6 +16,13 @@ on:
         required: true
         type: string
 
+# Required for npm Trusted Publishing (OIDC). id-token: write lets the runner
+# mint the short-lived OIDC token that npm exchanges for publish access — no
+# long-lived NPM_TOKEN secret is used anymore.
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   publish-single-package:
     name: Publish Single DtoForge Package
@@ -32,8 +39,13 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '22'
         registry-url: 'https://registry.npmjs.org'
+
+    # Trusted Publishing (OIDC) requires npm >= 11.5.1, newer than the npm
+    # bundled with Node. Upgrade before publishing.
+    - name: Update npm
+      run: npm install -g npm@latest
 
     - name: Get release version
       id: get_version
@@ -121,12 +133,16 @@ jobs:
         export VERSION="${{ steps.get_version.outputs.version }}"
         envsubst < ../scripts/npm/package.json.template > package.json
 
+    # Authenticates via OIDC Trusted Publishing — no NODE_AUTH_TOKEN/NPM_TOKEN.
+    # --provenance attaches a signed build-provenance attestation (enabled by
+    # trusted publishing). The npm package must have a Trusted Publisher
+    # configured on npmjs.com pointing at this repo + workflow file.
     - name: Publish to npm
       run: |
         cd npm-package
-        npm publish --access public
+        npm publish --provenance --access public
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NODE_AUTH_TOKEN: ""
 
     - name: Summary
       run: |


### PR DESCRIPTION
## Why

The v1.7.3 npm publish failed with a `404` on `PUT .../dtoforge`. That's npm's **masked auth error** — the `NPM_TOKEN` (set 2026-02-19, last worked 2026-03-08) had expired. Rather than rotate another long-lived token, switch to npm **Trusted Publishing via GitHub OIDC** — the same setup already used in `imposters`.

This is **not** a version issue: `dtoforge` exists on npm (owned by this account, `latest = 1.7.2`), and `1.7.3` is a valid new version.

## What changed (`.github/workflows/npm-publish.yaml`)

- **`permissions: id-token: write`** — lets the runner mint the short-lived OIDC token npm exchanges for publish access.
- **Node 22 + `npm install -g npm@latest`** — Trusted Publishing requires **npm ≥ 11.5.1**, newer than the npm bundled with Node (the old `node 18` would have blocked OIDC even with a valid token).
- **`npm publish --provenance --access public`**, with `NODE_AUTH_TOKEN: ""` — no `NPM_TOKEN` secret. `--provenance` attaches a signed build-provenance attestation.

The existing flow is otherwise unchanged: `Release` builds the Go binaries → this workflow downloads them from the release → publishes.

## Required on the npm side (one-time, already done by maintainer)

A **Trusted Publisher** must be configured for the `dtoforge` package on npmjs.com:
- Repository: `eliraz-refael/dtoForge`
- Workflow filename: **`npm-publish.yaml`**
- Environment: **`production`** (the job runs with `environment: production`)

If any of those three don't match the npm config, OIDC auth fails — worth double-checking before the first publish.

## Publishing 1.7.3 after merge

The `v1.7.3` GitHub release + binaries already exist, so no new release is needed — re-run via `workflow_dispatch` from `master`:

```
gh workflow run npm-publish.yaml -f version=1.7.3 -f release_tag=v1.7.3
```

The old `NPM_TOKEN` secret can be deleted from the `production` environment once this is confirmed working.